### PR TITLE
Added stopPolling method to stop polling after unregistering the device

### DIFF
--- a/modules/mobile-agents/android/client/res/values/strings.xml
+++ b/modules/mobile-agents/android/client/res/values/strings.xml
@@ -168,7 +168,7 @@
     <string name="shared_pref_message_mode">mode</string>
     <string name="shared_pref_interval">interval</string>
     <string name="username">username</string>
-    <string name="shared_pref_device_active">0</string>
+    <string name="shared_pref_device_active">deviceActive</string>
     <string name="shared_pref_client_id">ClientID</string>
     <string name="shared_pref_client_secret">ClientSecret</string>
     <string name="shared_pref_operators">operators</string>

--- a/modules/mobile-agents/android/client/src/org/wso2/mdm/agent/AlreadyRegisteredActivity.java
+++ b/modules/mobile-agents/android/client/src/org/wso2/mdm/agent/AlreadyRegisteredActivity.java
@@ -84,8 +84,8 @@ public class AlreadyRegisteredActivity extends SherlockActivity implements APIRe
 		resources = context.getResources();
 		Bundle extras = getIntent().getExtras();
 
-		if (extras != null) {
-			if (extras.
+        if (extras != null) {
+            if (extras.
 					containsKey(getResources().getString(R.string.intent_extra_fresh_reg_flag))) {
 				freshRegFlag = extras.getBoolean(
                                  getResources().getString(R.string.intent_extra_fresh_reg_flag));
@@ -94,9 +94,9 @@ public class AlreadyRegisteredActivity extends SherlockActivity implements APIRe
 		}
 
 		String registrationId =
-				Preference.getString(context, resources.
+                Preference.getString(context, resources.
 				                     			getString(R.string.shared_pref_regId));
-		
+
 		if (registrationId != null && !registrationId.isEmpty()) {
 			regId = registrationId;
 		}
@@ -111,7 +111,7 @@ public class AlreadyRegisteredActivity extends SherlockActivity implements APIRe
 
 			freshRegFlag = false;
 		}
-		
+
 		txtRegText = (TextView) findViewById(R.id.txtRegText);
 		btnUnregister = (Button) findViewById(R.id.btnUnreg);
 		btnUnregister.setTag(TAG_BTN_UNREGISTER);
@@ -119,7 +119,7 @@ public class AlreadyRegisteredActivity extends SherlockActivity implements APIRe
 		LocalNotification.startPolling(context);
 
 	}
-	
+
 	private DialogInterface.OnClickListener dialogClickListener = new DialogInterface.OnClickListener() {
 		@Override
 		public void onClick(DialogInterface dialog, int which) {
@@ -163,9 +163,7 @@ public class AlreadyRegisteredActivity extends SherlockActivity implements APIRe
 				@Override
 				public void onClick(DialogInterface arg0,
 				                    int arg1) {
-
 					loadServerDetailsActivity();
-
 				}
 			};
 
@@ -284,11 +282,10 @@ public class AlreadyRegisteredActivity extends SherlockActivity implements APIRe
 			} else {
 				CommonDialogUtils.showNetworkUnavailableMessage(AlreadyRegisteredActivity.this);
 			}
-
 		}
 
 	}
-	
+
 	/**
 	 * Displays an internal server error message to the user.
 	 */
@@ -300,19 +297,15 @@ public class AlreadyRegisteredActivity extends SherlockActivity implements APIRe
                                             null);
 		alertDialog.show();
 	}
-	
+
 	/**
 	 * Clears application data and displays unregister success message.
 	 */
 	private void clearAppData() {
 		CommonUtils.clearAppData(context);
-
-		alertDialog = CommonDialogUtils.getAlertDialogWithOneButtonAndTitle(context,
-                                            getResources().getString(R.string.title_head_registration_error),
-                                            getResources().getString(R.string.error_for_all_unknown_registration_failures),
-                                            getResources().getString(R.string.button_ok),
-                                            isRegisteredFailedOKBtnClickListerner);
-		alertDialog.show();
+        if (Constants.DEBUG_MODE_ENABLED) {
+            Log.d(TAG, "App data cleared");
+        }
 	}
 
 	@Override
@@ -325,6 +318,7 @@ public class AlreadyRegisteredActivity extends SherlockActivity implements APIRe
 				responseStatus = result.get(Constants.STATUS_KEY);
 				if (Constants.REQUEST_SUCCESSFUL.equals(responseStatus)) {
 					clearAppData();
+                    initiateUnregistration();
 				} else if (Constants.INTERNAL_SERVER_ERROR.equals(responseStatus)) {
 					displayInternalServerError();
 				} else {
@@ -344,7 +338,7 @@ public class AlreadyRegisteredActivity extends SherlockActivity implements APIRe
 					displayInternalServerError();
 				} else if (!Constants.REQUEST_SUCCESSFUL.equals(responseStatus)) {
 					initiateUnregistration();
-				} 
+				}
 			} else {
 				clearAppData();
 			}
@@ -352,11 +346,11 @@ public class AlreadyRegisteredActivity extends SherlockActivity implements APIRe
 		}
 
 	}
-	
+
 	/**
 	 * Load device home screen.
 	 */
-	
+
 	private void loadHomeScreen(){
 		Intent i = new Intent();
 		i.setAction(Intent.ACTION_MAIN);
@@ -364,7 +358,7 @@ public class AlreadyRegisteredActivity extends SherlockActivity implements APIRe
 		this.startActivity(i);
 		super.onBackPressed();
 	}
-	
+
 	/**
 	 * Initiate unregistration.
 	 */
@@ -373,9 +367,10 @@ public class AlreadyRegisteredActivity extends SherlockActivity implements APIRe
 		btnUnregister.setText(R.string.register_button_text);
 		btnUnregister.setTag(TAG_BTN_RE_REGISTER);
 		btnUnregister.setOnClickListener(onClickListenerButtonClicked);
+        LocalNotification.stopPolling(context);
 		CommonUtils.clearAppData(context);
 	}
-	
+
 	/**
 	 * Start device admin activation request.
 	 * @param cdmDeviceAdmin - Device admin component.
@@ -384,11 +379,11 @@ public class AlreadyRegisteredActivity extends SherlockActivity implements APIRe
 		Intent deviceAdminIntent = new Intent(DevicePolicyManager.ACTION_ADD_DEVICE_ADMIN);
 		deviceAdminIntent.putExtra(DevicePolicyManager.EXTRA_DEVICE_ADMIN, cdmDeviceAdmin);
 		deviceAdminIntent.putExtra(DevicePolicyManager.EXTRA_ADD_EXPLANATION,
-		                           getResources()
+                getResources()
 				                           .getString(R.string.device_admin_enable_alert));
 		startActivityForResult(deviceAdminIntent, ACTIVATION_REQUEST);
 	}
-	
+
 	/**
 	 * Display unregistration confirmation dialog.
 	 */
@@ -397,12 +392,12 @@ public class AlreadyRegisteredActivity extends SherlockActivity implements APIRe
 				new AlertDialog.Builder(
 						AlreadyRegisteredActivity.this);
 		builder.setMessage(getResources().getString(R.string.dialog_unregister))
-		       .setNegativeButton(getResources().getString(R.string.yes),
-		                          dialogClickListener)
-		       .setPositiveButton(getResources().getString(R.string.no),
+                .setNegativeButton(getResources().getString(R.string.yes),
+                        dialogClickListener)
+                .setPositiveButton(getResources().getString(R.string.no),
 		                          dialogClickListener).show();
 	}
-	
+
 	/**
 	 * Load device info activity.
 	 */
@@ -414,7 +409,7 @@ public class AlreadyRegisteredActivity extends SherlockActivity implements APIRe
 		                  AlreadyRegisteredActivity.class.getSimpleName());
 		startActivity(intent);
 	}
-	
+
 	/**
 	 * Load server details activity.
 	 */
@@ -432,7 +427,7 @@ public class AlreadyRegisteredActivity extends SherlockActivity implements APIRe
 		startActivity(intent);
 		finish();
 	}
-	
+
 	/**
 	 * Load PIN code activity.
 	 */

--- a/modules/mobile-agents/android/client/src/org/wso2/mdm/agent/services/AgentDeviceAdminReceiver.java
+++ b/modules/mobile-agents/android/client/src/org/wso2/mdm/agent/services/AgentDeviceAdminReceiver.java
@@ -58,7 +58,7 @@ public class AgentDeviceAdminReceiver extends DeviceAdminReceiver implements API
 
 		MessageProcessor processor = new MessageProcessor(context);
 		processor.getMessages();
-		
+
 		Toast.makeText(context, R.string.device_admin_enabled,
 		               Toast.LENGTH_LONG).show();
 		LocalNotification.startPolling(context);
@@ -88,26 +88,26 @@ public class AgentDeviceAdminReceiver extends DeviceAdminReceiver implements API
 	public void startUnRegistration(Context context) {
 		String regId = Preference.getString(context, context
 				.getResources().getString(R.string.shared_pref_regId));
-
+        LocalNotification.stopPolling(context);
 		JSONObject requestParams = new JSONObject();
 		try {
 			requestParams.put(context.getResources().getString(R.string.shared_pref_regId), regId);
 		} catch (JSONException e) {
 			Log.e(TAG, "Registration ID not retrieved." + e.toString());
 		}
-		
+
 		CommonUtils.clearAppData(context);
-		CommonUtils.callSecuredAPI(context,
-		                           Constants.UNREGISTER_ENDPOINT,
-		                           HTTP_METHODS.POST, requestParams,
-		                           AgentDeviceAdminReceiver.this,
-		                           Constants.UNREGISTER_REQUEST_CODE);
+        CommonUtils.callSecuredAPI(context,
+                Constants.UNREGISTER_ENDPOINT,
+                HTTP_METHODS.POST, requestParams,
+                AgentDeviceAdminReceiver.this,
+                Constants.UNREGISTER_REQUEST_CODE);
 	}
 
 	@Override
 	public void onPasswordChanged(Context context, Intent intent) {
 		super.onPasswordChanged(context, intent);
-		if (Constants.DEBUG_MODE_ENABLED) { 
+		if (Constants.DEBUG_MODE_ENABLED) {
 			Log.d(TAG, "onPasswordChanged.");
 		}
 	}

--- a/modules/mobile-agents/android/client/src/org/wso2/mdm/agent/services/LocalNotification.java
+++ b/modules/mobile-agents/android/client/src/org/wso2/mdm/agent/services/LocalNotification.java
@@ -28,27 +28,37 @@ import android.os.SystemClock;
  * polls to server based on a predefined to retrieve pending data.
  */
 public class LocalNotification {
-	public static boolean localNoticicationInvoked = false;
-	public static int DEFAULT_INTERVAL = 10000;
-	public static int DEFAULT_BUFFER = 1000;
-	public static int REQUEST_CODE = 0;
+    public static boolean localNoticicationInvoked = false;
+    public static int DEFAULT_INTERVAL = 30000;
+    public static int DEFAULT_BUFFER = 1000;
+    public static int REQUEST_CODE = 0;
 
-	public static void startPolling(Context context) {
-		int interval = DEFAULT_INTERVAL;
+    public static void startPolling(Context context) {
+        int interval = DEFAULT_INTERVAL;
 
-		long currentTime = SystemClock.elapsedRealtime();
-		currentTime += DEFAULT_BUFFER;
-		if (localNoticicationInvoked == false) {
-			localNoticicationInvoked = true;
-			Intent alarm = new Intent(context, AlarmReceiver.class);
-			PendingIntent recurringAlarm =
-					PendingIntent.getBroadcast(context,
-					                           REQUEST_CODE,
-					                           alarm,
-					                           PendingIntent.FLAG_CANCEL_CURRENT);
-			AlarmManager alarms = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
-			alarms.setRepeating(AlarmManager.ELAPSED_REALTIME_WAKEUP, currentTime, interval,
-			                    recurringAlarm);
-		}
-	}
+        long currentTime = SystemClock.elapsedRealtime();
+        currentTime += DEFAULT_BUFFER;
+        if (localNoticicationInvoked == false) {
+            localNoticicationInvoked = true;
+            Intent alarm = new Intent(context, AlarmReceiver.class);
+            PendingIntent recurringAlarm =
+                    PendingIntent.getBroadcast(context,
+                            REQUEST_CODE,
+                            alarm,
+                            PendingIntent.FLAG_CANCEL_CURRENT);
+            AlarmManager alarms = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+            alarms.setRepeating(AlarmManager.ELAPSED_REALTIME_WAKEUP, currentTime, interval,
+                    recurringAlarm);
+        }
+    }
+
+    public static void stopPolling(Context context) {
+        if (localNoticicationInvoked == true) {
+            localNoticicationInvoked = false;
+            Intent alarm = new Intent(context, AlarmReceiver.class);
+            PendingIntent sender = PendingIntent.getBroadcast(context, REQUEST_CODE, alarm, 0);
+            AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+            alarmManager.cancel(sender);
+        }
+    }
 }

--- a/modules/mobile-agents/android/client/src/org/wso2/mdm/agent/utils/CommonUtils.java
+++ b/modules/mobile-agents/android/client/src/org/wso2/mdm/agent/utils/CommonUtils.java
@@ -113,6 +113,8 @@ public class CommonUtils {
 		                 resources.getString(R.string.shared_pref_default_string));
 		editor.putString(context.getResources().getString(R.string.shared_pref_eula),
 		                 resources.getString(R.string.shared_pref_default_string));
+        editor.putString(resources.getString(R.string.shared_pref_device_active),
+                         resources.getString(R.string.shared_pref_reg_fail));
 		editor.commit();
 		
 		devicePolicyManager.removeActiveAdmin(demoDeviceAdmin);

--- a/modules/mobile-agents/android/client/src/org/wso2/mdm/agent/utils/CommonUtils.java
+++ b/modules/mobile-agents/android/client/src/org/wso2/mdm/agent/utils/CommonUtils.java
@@ -113,8 +113,8 @@ public class CommonUtils {
 		                 resources.getString(R.string.shared_pref_default_string));
 		editor.putString(context.getResources().getString(R.string.shared_pref_eula),
 		                 resources.getString(R.string.shared_pref_default_string));
-        editor.putString(resources.getString(R.string.shared_pref_device_active),
-                         resources.getString(R.string.shared_pref_reg_fail));
+        	editor.putString(resources.getString(R.string.shared_pref_device_active),
+                         	 resources.getString(R.string.shared_pref_reg_fail));
 		editor.commit();
 		
 		devicePolicyManager.removeActiveAdmin(demoDeviceAdmin);


### PR DESCRIPTION
Current application poll even after the device get unregistered which makes unnecessary network traffic between device and server. It was fixed.